### PR TITLE
False positive FORM cases for prodigy annotation model training

### DIFF
--- a/notebooks/strata/002_Get_False_FORM_Entity_Examples.ipynb
+++ b/notebooks/strata/002_Get_False_FORM_Entity_Examples.ipynb
@@ -1,0 +1,464 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Aim\n",
+    "\n",
+    "Create a sample of sentences containing FORM entity False Positive strings (i.e., strings that look like FORMs but are not) to train the annotation prodigy-spacy model.\n",
+    "\n",
+    "These cases will be extracted from the following document types:\n",
+    "-'html_publication', \n",
+    "- 'research', \n",
+    "- 'aaib_report', \n",
+    "- 'employment_tribunal_decision',\n",
+    "- 'research',\n",
+    "- 'impact_assessment',\n",
+    "- 'notice'\n",
+    "\n",
+    "### Requirements\n",
+    "\n",
+    "Please down a copy of the pre-processed content store, following [these](./src/strata/README.md) instructions.\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import gc\n",
+    "import re\n",
+    "import pandas as pd\n",
+    "from tqdm.notebook import tqdm\n",
+    "\n",
+    "import sys\n",
+    "import json\n",
+    "\n",
+    "from src.make_data.make_data import load_preprocessed_content_store\n",
+    "from src.strata.sample_paths_by_strata import get_stratified_sample\n",
+    "\n",
+    "pd.set_option('max_colwidth', 400)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DIR_OUTPUT = os.environ.get('DIR_DATA_PROCESSED')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "DIR_OUTPUT"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## User-defined elements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OUPUT_FILEPATH = os.path.join(DIR_OUTPUT, 'fake_forms_sentences.jsonl')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TARGET_DOCUMENT_TYPES = ['html_publication', \n",
+    "                         'research', \n",
+    "                         'aaib_report', \n",
+    "                         'employment_tribunal_decision',\n",
+    "                         'research',\n",
+    "                         'impact_assessment',\n",
+    "                         'notice'\n",
+    "                        ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "STRATA_WEIGHTS = {'html_publication': 1, \n",
+    "                         'research' : 1 , \n",
+    "                         'aaib_report' : 1, \n",
+    "                         'employment_tribunal_decision' : 1,\n",
+    "                         'research' : 1,\n",
+    "                         'impact_assessment' : 1,\n",
+    "                         'notice' : 1}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Load the content data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = load_preprocessed_content_store(path_to_gz='/tmp/govukmirror/preprocessed_content_store_250522.csv.gz')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Filter for the rekevant document types\n",
+    "\n",
+    "These are document types that are likley to contain strings that look like FORMs but are not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_content_df = df.query(\"document_type in @TARGET_DOCUMENT_TYPES\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_content_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# free memory\n",
+    "del df\n",
+    "gc.collect()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Filter relevant columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_content_df = target_content_df[['base_path', 'content_id', 'title', \n",
+    "                                       'description', 'text', 'document_type']].copy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_content_df.head(3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Identify strings that look-alike FORM"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def has_numbers(inputString):\n",
+    "    return any(char.isdigit() for char in inputString)\n",
+    "\n",
+    "def has_alpha(inputString):\n",
+    "    return any(char.isalpha() for char in inputString)\n",
+    "\n",
+    "def has_special(inputString):\n",
+    "    return any(not char.isalnum() for char in inputString)\n",
+    "    \n",
+    "def detectFormName(inputString):\n",
+    "    inputString = inputString.replace(':', '')\n",
+    "    outputString = [token for token in inputString.split() if has_numbers(token) and has_alpha(token) and has_special(token)]\n",
+    "    if outputString:\n",
+    "        return inputString"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### In titles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "title_results = []\n",
+    "for doc_type, base_path, cid, title in zip(target_content_df['document_type'],\n",
+    "                                 target_content_df['base_path'], \n",
+    "                                 target_content_df['content_id'], \n",
+    "                                 target_content_df['title']):\n",
+    "    # extract the sentences from the page with a crude heuristic, then iterate over those\n",
+    "    try: \n",
+    "        out = detectFormName(title)\n",
+    "        if out:\n",
+    "            title_results.append((out, base_path, cid, doc_type))\n",
+    "    except AttributeError as e:\n",
+    "        continue\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Extracting sentences containing fake forms\n",
+    "\n",
+    "#TODO: refactor into function and improve performance of code"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = []\n",
+    "for doc_type, base_path, cid, text in zip(target_content_df['document_type'],\n",
+    "                                target_content_df['base_path'], \n",
+    "                                target_content_df['content_id'], \n",
+    "                                target_content_df['text']):\n",
+    "    # extract the sentences from the page with a crude heuristic, then iterate over those\n",
+    "    try: \n",
+    "        sents = re.split(r' *[\\.\\?!][\\'\"\\)\\]]* *', text)\n",
+    "        for sent in sents:\n",
+    "            out = detectFormName(sent)\n",
+    "            if out:\n",
+    "                results.append((out, base_path, cid, doc_type))\n",
+    "    except AttributeError as e:\n",
+    "        continue\n",
+    "    except TypeError as e:\n",
+    "        continue"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(results)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Join the two"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fake_forms_results = title_results + results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(fake_forms_results)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fake_forms_results_df = pd.DataFrame(fake_forms_results, columns=['text', 'base_path', 'content_id', 'doc_type'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "###  Random sampled stratified by document type"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fake_forms_results_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fake_forms_results_sample = get_stratified_sample(df = fake_forms_results_df, \n",
+    "                      strata_col = \"doc_type\", \n",
+    "                      weights = STRATA_WEIGHTS, \n",
+    "                      sample_size = 501)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fake_forms_results_sample.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# shuffle\n",
+    "fake_forms_results_sample = fake_forms_results_sample.sample(frac=1).copy()\n",
+    "fake_forms_results_sample.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Convert to Prodigy format"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A bit of a hack"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "collection = []\n",
+    "for base_path, cid, text in zip(fake_forms_results_sample['base_path'], \n",
+    "                                fake_forms_results_sample['content_id'], \n",
+    "                                fake_forms_results_sample['text']):\n",
+    "    out_dict = {'text': text, 'meta': {'base_path': base_path, 'content_id': cid}}\n",
+    "    collection.append(out_dict)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Write to JSON lines"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(OUPUT_FILEPATH, 'w') as fp:\n",
+    "    for item in collection:\n",
+    "        fp.write(json.dumps(item, ensure_ascii=False) + \"\\n\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "interpreter": {
+   "hash": "aee8b7b246df8f9039afb4144a1f6fd8d2ca17a180786b69acc140d282b71a49"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
Added `notebooks/strata/002_Get_False_FORM_Entity_Examples.ipynb`
to extract sentences with false positive cases of FORM entities from a diverse set of document types

# Summary

The notebook outputs a random sample (stratified by document type) of sentences that contain strings of text that look like FORM but are not. 


# Checklists

<!--
These are do-confirm checklists; it confirms that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [x] code runs
- [x] [developments are ethical][data-ethics-framework] and secure
- [x] you have made proportionate checks that the code works correctly
- [ ] test suite passes
- [ ] developments adhere to AQA plan (see `docs/aqa/aqa_plan.md`)
- [ ] data log updated (see `docs/aqa/data_log.md`), if necessary
- [ ] assumptions, and caveats log updated (see `docs/aqa/assumptions_caveats.md`), if
  necessary
- [ ] [minimum usable documentation][agilemodeling] written in the `docs` folder

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
