### PR TITLE
Notebook update to extracted extra examples with PERSON instances

### DIFF
--- a/notebooks/strata/003_Get_extra_phase1_entity_examples.ipynb
+++ b/notebooks/strata/003_Get_extra_phase1_entity_examples.ipynb
@@ -139,7 +139,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "OUPUT_FILEPATH"
+    "OUPUT_FILEPATH1"
    ]
   },
   {
@@ -846,6 +846,205 @@
    "outputs": [],
    "source": [
     "export_to_jsonl(rand_sample2, OUPUT_FILEPATH2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Update: extract extra sentences with PERSON entity instances"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TARGET_ENTITY = [\"PERSON\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OUPUT_FILEPATH3 = os.path.join(\n",
+    "    DIR_OUTPUT, f\"{SAMPLE_DATE}_phase1_extra_training_examples_n3_person.jsonl\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# contain possible target entity?\n",
+    "contain_person = []\n",
+    "for doc in nlp_sentences:\n",
+    "    if any(ent.label_ in TARGET_ENTITY for ent in doc.ents):\n",
+    "        contain_person.append(True)\n",
+    "    else:\n",
+    "        contain_person.append(False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(contain_person)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Number of sentences that potentially contain one of the target entities\n",
+    "sum(contain_person)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exploded_df[\"contain_person\"] = contain_person"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exploded_df[exploded_df.contain_person == True].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "person_df = exploded_df[\n",
+    "    ~exploded_df.sentences.isin(rand_sample_texts.sentences)\n",
+    "    & exploded_df.contain_person\n",
+    "    == True\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "person_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "person_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "person_df.groupby(\"document_type\").count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "CHOSEN_DOCTYPES = [\n",
+    "    \"working_group\",\n",
+    "    \"speech\",\n",
+    "    \"press_release\",\n",
+    "    \"person\",\n",
+    "    \"news_story\",\n",
+    "    \"correspondence\",\n",
+    "]\n",
+    "person_df[person_df.document_type.isin(CHOSEN_DOCTYPES)].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_person_df = person_df[person_df.document_type.isin(CHOSEN_DOCTYPES)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_person_texts = (\n",
+    "    target_person_df[[\"base_path\", \"document_type\", \"sentences\"]]\n",
+    "    .rename(columns={\"sentences\": \"text\"})\n",
+    "    .reset_index(drop=True)\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "target_person_jsonl = from_df_to_jsonl(target_person_texts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(target_person_jsonl)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "export_to_jsonl(target_person_jsonl, OUPUT_FILEPATH3)"
    ]
   },
   {


### PR DESCRIPTION
Should be a quick review. 
Expanded `notebooks/strata/003_Get_extra_phase1_entity_examples.ipynb` to extract extra examples containing PERSON entity types.

# Checklists

<!--
These are do-confirm checklists; it confirms that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [x] code runs
- [ ] [developments are ethical][data-ethics-framework] and secure
- [ ] you have made proportionate checks that the code works correctly
- [ ] test suite passes
- [ ] developments adhere to AQA plan (see `docs/aqa/aqa_plan.md`)
- [ ] data log updated (see `docs/aqa/data_log.md`), if necessary
- [ ] assumptions, and caveats log updated (see `docs/aqa/assumptions_caveats.md`), if
  necessary
- [ ] [minimum usable documentation][agilemodeling] written in the `docs` folder

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
