### PR TITLE
updated .pre-commit-config.yaml 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
       - id: black
         name: black - consistent Python code formatting (auto-fixes)
         language_version: python3.9 # Should be a command that runs python3.9+
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/PyCQA/flake8
     rev: 3.9.2
     hooks:
       - id: flake8


### PR DESCRIPTION
Changing to new repo `https://github.com/PyCQA/flake8` instead of `[...]gitlab/[...]` because the tests for the hook were failing in GitHUb Action CI/CD.

As suggested in: https://github.com/AICoE/aicoe-ci/issues/53

