### PR TITLE
added SQL for entities post-extraction processing and aggregation

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,20 @@ aws s3 ls --profile govuk-datascience
 [infer-entities-sh]: ./src/make_data/infer_entities.sh
 [ds-role]: https://us-east-1.console.aws.amazon.com/iamv2/home?region=eu-west-1#/roles/details/govuk-datascienceusers?section=permissions
 [awscli-install]: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
+
+
+## Named entities: Post-extraction processing and aggregation
+
+After the named entities are extracted by the model and uploaded to tables in the BigQuery `cpto-content-metadata.named_entities.named_entities_raw` dataset, the outputs undergoes further processing and aggregation.
+
+This post-extraction processing are executed by the [src/make_data/sql_queries/post_entity_extraction_processing.sql][src/make_data/sql_queries/post_entity_extraction_processing.sql] query, which is scheduled to run twice a month 1h after the bulk inference pipeline is expected to be finished.
+
+The query schedule is available at [cpto-content-metadata Big Query - scheduled queries] (https://console.cloud.google.com/bigquery/scheduled-queries?project=cpto-content-metadata).
+
+The query produces two BigQuey tables:
+
+1. `cpto-content-metadata.named_entities.named_entities_all`:  one line per individual entity instance with as much noise as possible removed;
+
+2. `cpto-content-metadata.named_entities.named_entities_counts`: aggregated table of counts of entity-type per url;
+
+Table (2.) is in the format for govGraph ingestion.

--- a/src/make_data/sql_queries/post_entity_extraction_processing.sql
+++ b/src/make_data/sql_queries/post_entity_extraction_processing.sql
@@ -1,0 +1,115 @@
+-- This sql script creates/replace two tables:
+-- (1) cpto-content-metadata.named_entities.named_entities_all
+-- (2) cpto-content-metadata.named_entities.named_entities_counts
+
+-- At the moment, this query is attached to the following schedule
+-- found at: https://console.cloud.google.com/bigquery/scheduled-queries/locations/ \
+--     us/configs/63d1df30-0000-2629-90c0-001a114d40b2/runs?project=cpto-content-metadata
+
+
+-- (1) post-extraction cleaning:
+-- create a new column containing the lower-case name of the entity instance
+-- REMOVE NOISE 1: exclude entity instances that start with non-ascii symbol (e.g., '- hello') and are tagged as ORG
+-- REMOVE NOISE 2: exclude entities that consist of a single character
+-- REMOVE NOISE 3: exclude entity instances that contain no ascii character at all
+-- create url for each unique combination of entity's name and type
+-- only keep lines with entities extracted
+CREATE OR REPLACE TABLE `cpto-content-metadata.named_entities.named_entities_all` AS
+
+WITH ents_all AS (
+SELECT
+  url,
+  entities[SAFE_OFFSET(0)].name,
+  LOWER(entities[SAFE_OFFSET(0)].name) AS name_lower,
+  entities[SAFE_OFFSET(0)].type,
+  'title' AS part_of_page
+FROM `cpto-content-metadata.named_entities_raw.title_1`
+WHERE entities[SAFE_OFFSET(0)].name IS NOT null
+UNION ALL
+SELECT
+  url,
+  entities[SAFE_OFFSET(0)].name,
+  LOWER(entities[SAFE_OFFSET(0)].name) AS name_lower,
+  entities[SAFE_OFFSET(0)].type,
+  'description' AS part_of_page
+FROM `cpto-content-metadata.named_entities_raw.description_1`
+WHERE entities[SAFE_OFFSET(0)].name IS NOT null
+UNION ALL
+SELECT
+  url,
+  entities[SAFE_OFFSET(0)].name AS name,
+  LOWER(entities[SAFE_OFFSET(0)].name) AS name_lower,
+  entities[SAFE_OFFSET(0)].type,
+  'text' AS part_of_page
+FROM `cpto-content-metadata.named_entities_raw.text_1`
+WHERE entities[SAFE_OFFSET(0)].name IS NOT null
+)
+-- REMOVE NOISE 1: exclude entity instances that start with non-ascii symbol (e.g., '- hello') and are tagged as ORG
+-- REMOVE NOISE 2: exclude entities that consist of a single character
+-- REMOVE NOISE 3: exclude entity instances that contain no ascii character at all
+-- create url for each unique combination of entity's name and type
+SELECT
+  *,
+  CONCAT('https://www.gov.uk/named-entity/', REPLACE(name_lower, ' ', '_'), type) AS url_entity_nametype,
+FROM ents_all
+WHERE (NOT (REGEXP_CONTAINS(name_lower, r"^[^\p{ASCII}]") AND type="ORG")) AND (NOT (REGEXP_CONTAINS(name_lower, r'^[�#£"]') AND type='ORG')) AND (CHAR_LENGTH(name_lower) > 1) AND (ARRAY_LENGTH(REGEXP_EXTRACT_ALL(REPLACE(name_lower, ' ', ''), r"[\p{ASCII}]")) > 0)
+ORDER BY url
+;
+
+
+-- (2) aggregate and count
+CREATE OR REPLACE TABLE `cpto-content-metadata.named_entities.named_entities_counts` AS
+
+WITH title_counts AS (
+SELECT
+  url, name_lower, type, url_entity_nametype,
+  COUNT(*) OVER (PARTITION BY url, name_lower, type, url_entity_nametype) AS title_count
+FROM `cpto-content-metadata.named_entities.named_entities_all`
+WHERE part_of_page = "title"
+),
+
+description_counts AS (
+SELECT
+  url, name_lower, type, url_entity_nametype,
+  COUNT(*) OVER (PARTITION BY url, name_lower, type, url_entity_nametype) AS description_count
+FROM `cpto-content-metadata.named_entities.named_entities_all`
+WHERE part_of_page = "description"
+),
+
+text_counts AS (
+SELECT
+  url, name_lower, type, url_entity_nametype,
+  COUNT(*) OVER (PARTITION BY url, name_lower, type, url_entity_nametype) AS text_count
+FROM `cpto-content-metadata.named_entities.named_entities_all`
+WHERE part_of_page = "text"
+),
+
+total_counts AS (
+  SELECT
+  url, name_lower, type, url_entity_nametype,
+  COUNT(*) AS total_count
+FROM `cpto-content-metadata.named_entities.named_entities_all`
+GROUP BY url, name_lower, type, url_entity_nametype
+),
+
+combined_counts AS (
+SELECT
+  *
+  FROM title_counts
+  FULL JOIN description_counts USING(url, name_lower, type, url_entity_nametype)
+  FULL JOIN text_counts USING(url, name_lower, type, url_entity_nametype)
+  FULL JOIN total_counts USING(url, name_lower, type, url_entity_nametype)
+)
+
+SELECT DISTINCT
+ url,
+ name_lower,
+ type,
+ url_entity_nametype,
+ IFNULL(title_count, 0) AS title_count,
+ IFNULL(description_count, 0) AS description_count,
+ IFNULL(text_count, 0) AS text_count,
+ IFNULL(total_count, 0) AS total_count,
+FROM combined_counts
+ORDER BY url
+;


### PR DESCRIPTION
# Summary

This PR contains a copy of the SQL query that creates the following Big Query tables:

1. [cpto-content-metadata.named_entities.named_entities_all](https://console.cloud.google.com/bigquery?project=cpto-content-metadata&ws=!1m5!1m4!4m3!1scpto-content-metadata!2snamed_entities!3snamed_entities_all): one line per individual entity instance with as much noise as possible removed (post extraction);
2. [cpto-content-metadata.named_entities.named_entities_counts](https://console.cloud.google.com/bigquery?project=cpto-content-metadata&ws=!1m5!1m4!4m3!1scpto-content-metadata!2snamed_entities!3snamed_entities_counts): aggregated table of counts of entity-type per url.

Table (2) is ready to be imported to the knowledge graph (pending review of the sql).

At the moment, the query is scheduled to run on the 1st and 15th each month at 7PM, one hour after the bulk inference pipeline is scheduled to terminate [here is the schedule](https://console.cloud.google.com/bigquery/scheduled-queries/locations/us/configs/63d1df30-0000-2629-90c0-001a114d40b2/runs?project=cpto-content-metadata). However, the longer-term plan is to set up a trigger to run it when the last tables with extracted entities is created.

I created a test for the main cleaning step, which can be found at https://console.cloud.google.com/bigquery?sq=673804617052:c4ed5b8b1ec8465e94318eee32922072 

The original sql query is saved in the cpto-content-metadata BigQuery space, under Saved Queries.

@rory-hurley-gds - I have added you as reviewer.
@nacnudus pinging you here so that you have sight of this.

Thanks.

# Checklists

<!--
These are do-confirm checklists; it confirms that you have DOne each item.

Outstanding actions should be completed before reviewers are assigned; if actions are
irrelevant, please try and add a comment stating why.

Incomplete pull/merge requests may be blocked until actions are resolved, or closed at
the reviewers' discretion.
-->

This pull/merge request meets the following requirements:

- [x] code runs
- [x] [developments are ethical][data-ethics-framework] and secure
- [x] you have made proportionate checks that the code works correctly
- [x] test suite passes
- [x] developments adhere to AQA plan (see `docs/aqa/aqa_plan.md`)
- [ ] data log updated (see `docs/aqa/data_log.md`), if necessary
- [ ] assumptions, and caveats log updated (see `docs/aqa/assumptions_caveats.md`), if
  necessary
- [x] [minimum usable documentation][agilemodeling] written in the `docs` folder

Comments have been added below around the incomplete checks.

[agilemodeling]: http://agilemodeling.com/essays/documentLate.htm
[data-ethics-framework]: https://www.gov.uk/government/publications/data-ethics-framework
