### PR TITLE
Update requirements.text to address critical dependant alert

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -243,7 +243,7 @@ tokenizers==0.12.1
 tomli==2.0.1
 tomlkit==0.11.6
 toolz==0.12.0
-torch==1.13.0
+torch>=1.13.1
 tornado==6.2
 traitlets==5.5.0
 typer==0.4.2


### PR DESCRIPTION
Updated torch to >=1.13.1 following dependabot alert.

Ref: https://github.com/alphagov/govuk-content-metadata/security/dependabot/14