### PR TITLE
Update .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
       - id: trailing-whitespace
         name: Check for trailing whitespaces (auto-fixes)
   - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort - Sort Python imports (auto-fixes)


### PR DESCRIPTION
Updated version of isort to 5.12.0 which contains fixes to the problem that was making pre-commit hooks to fail.
See: thttps://levelup.gitconnected.com/fix-runtimeerror-poetry-isort-5db7c67b60ff
