### PR TITLE
Updated GCP-Deploy.yml action to only run when changes to relevant path

### DIFF
--- a/.github/workflows/GCP-Deploy.yml
+++ b/.github/workflows/GCP-Deploy.yml
@@ -3,6 +3,8 @@ name: Docker
 on:
   pull_request:
     branches: [ main ]
+    paths:
+      - src/ner_streamlit_app/**
 
 jobs:
 


### PR DESCRIPTION
The GCP-Deploy workflow will only run when a pull request that includes a change in the sub-directory containing the streamlit app (and is opened on the main branch as before).

This will prevent this workflow to run if no change happened to the streamlit app that is deployed
