### PR TITLE
updated src/make_strata_extract_content_store.py to remove no longer existing app

### DIFF
--- a/src/make_strata/extract_content_store.py
+++ b/src/make_strata/extract_content_store.py
@@ -45,7 +45,6 @@ EXCLUSION_PUBLISHING_APP = [
     "share-sale-publisher",
     "short-url-manager",
     "smartanswers",
-    "special-route-publisher",
     "static",
 ]
 


### PR DESCRIPTION
Minor fix to delete a no longer existing app from the list of publishing app to exclude wheb building strata for sampling documents.